### PR TITLE
Disable show-trailing-whitespace

### DIFF
--- a/threes.el
+++ b/threes.el
@@ -73,6 +73,7 @@
 
 (define-derived-mode threes-mode special-mode "threes-mode"
   "A mode for play Threes."
+  (setq show-trailing-whitespace nil)
   (buffer-disable-undo))
 
 (defun threes-string-center (len s)


### PR DESCRIPTION
I have `(setq-default show-trailing-whitespace t)` in my `init.el`. (see [GNU Emacs Manual: Useless Whitespace](http://www.gnu.org/software/emacs/manual/html_node/emacs/Useless-Whitespace.html))
## Before

<img width="220" alt="2016-08-04 2 05 31" src="https://cloud.githubusercontent.com/assets/822086/17374641/8c805b68-59e8-11e6-8956-423f20f13325.png">
## After

<img width="224" alt="2016-08-04 2 05 48" src="https://cloud.githubusercontent.com/assets/822086/17374642/8c8aaf64-59e8-11e6-9879-7284907ed041.png">
